### PR TITLE
Update vicheck_hash2filename.py

### DIFF
--- a/src/Malformity/transforms/vicheck_hash2filename.py
+++ b/src/Malformity/transforms/vicheck_hash2filename.py
@@ -37,9 +37,9 @@ def dotransform(request, response):
     try:
     	list = page.find(text='File: ').findNext('b')
     except:
-    	raise MaltegoException('No DNS Queries')
+    	raise MaltegoException('No filename')
     
-    if list.text != 'none':
+    if list.text != '':
 		response += Filename(list.text)
     
     return response


### PR DESCRIPTION
fix empty filename entity being created when filename is empty (usually non-matched hashes)
